### PR TITLE
requestPermissions option included in scope

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -54,7 +54,7 @@ var getLoginUrlOptions = function(loginStyle, credentialToken, config, options) 
     }
     // All other request permissions in the options object is afterward parsed
     if (options.requestPermissions) {
-        _.union(scope, options.requestPermissions);
+        scope = _.union(scope, options.requestPermissions);
     }
 
     var loginUrlParameters = {};


### PR DESCRIPTION
Thanks for making a Microsoft handler for meteor accounts! It's working great for sign in but I was having trouble getting the `wl.emails` scope I needed onto the request. Made this change and tested locally under a package and working fine :smile:
